### PR TITLE
Add blogpost: "Logsearch presentation at London Elasticsearch Usergroup, Jan 2015"

### DIFF
--- a/blog/_posts/2015-02-23-logsearch-presentation-at-london-elasticsearch-usergroup-jan2015.md
+++ b/blog/_posts/2015-02-23-logsearch-presentation-at-london-elasticsearch-usergroup-jan2015.md
@@ -1,0 +1,13 @@
+---
+title: "Logsearch presentation at London Elasticsearch Usergroup, Jan 2015"
+description: "A presentation given on 2015-01-28 to the London Elasticsearch Usergroup on Logsearch"
+author: "David Laing"
+author_github: "mrdavidlaing"
+date: 2015-02-23T16:40:45Z
+---
+
+The presentation below ([youtube](http://youtu.be/Y3jFA4IAuf8)) introduces Logsearch as an ELK distribution; showing how the tooling provided by Logsearch can be used to develop, operate and extend a log analysis cluster based on the Elasticsearch ELK stack.
+
+<iframe width="650" height="365" src="//www.youtube.com/embed/Y3jFA4IAuf8" frameborder="0" allowfullscreen></iframe>
+
+The slides for the presentation are available [here](https://docs.google.com/presentation/d/1wVFnGg66rVwgm0NvOKkYa3-D3YULgYE1jS2Q6sM7SwY/pub?start=false&loop=false&delayms=3000)


### PR DESCRIPTION
Visible at http://logsearch-website-pr19.apps.cityindex.logsearch.io/blog/2015/02/logsearch-presentation-at-london-elasticsearch-usergroup-jan2015.html